### PR TITLE
Ajustando a porta do docker para servir a porta padrão do Postgres

### DIFF
--- a/game/docker-compose.yml
+++ b/game/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ./sql:/docker-entrypoint-initdb.d
     ports:
-      - "5434:5434"
+      - "5434:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U prision_break_user -d prision_break_db"]
       interval: 5s


### PR DESCRIPTION
Ajustando o docker para servir a porta "5432" na porta "5434", permitindo a conexão no Server Postgres de serviços externos do docker (Ex: Dbeaver apontando para porta local 5434)